### PR TITLE
Send quit before closing connection

### DIFF
--- a/foldingrig/foldingrig.py
+++ b/foldingrig/foldingrig.py
@@ -21,6 +21,9 @@ class client:
         if password:
             self.run(f'auth {password}')
 
+    def __del__(self):
+        self.connection.write(bytes('quit\n','utf8'))
+
     def run(self,cmd):
         try:
             self.connection.write(bytes(cmd + '\n','utf8'))


### PR DESCRIPTION
The client will never cleanup a connection unless it receives "quit" or there is a heartbeat active.